### PR TITLE
Abstract away with token manager

### DIFF
--- a/lib/Db/TokenMapper.php
+++ b/lib/Db/TokenMapper.php
@@ -52,7 +52,7 @@ class TokenMapper extends QBMapper {
 	 * @return Token
 	 * @throws DoesNotExistException
 	 */
-	public function getBytoken(string $token): Token {
+	public function getByToken(string $token): Token {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')
@@ -94,13 +94,15 @@ class TokenMapper extends QBMapper {
 		return $token;
 	}
 
-	public function cleanupTokens() {
+	public function getTokensForCleanup() {
 		// Clear all tokens older than 10 minutes
 		$time = $this->timeFactory->getTime() - (60 * 10);
 
 		$qb = $this->db->getQueryBuilder();
-		$qb->delete($this->getTableName())
+		$qb->select('*')
+			->from($this->getTableName())
 			->where($qb->expr()->lt('timestamp', $qb->createNamedParameter($time)));
-		$qb->execute();
+
+		return $this->findEntities($qb);
 	}
 }

--- a/lib/Exception/TokenExpireException.php
+++ b/lib/Exception/TokenExpireException.php
@@ -22,25 +22,8 @@ declare(strict_types=1);
  *
  */
 
-namespace OCA\TwoFactorNextcloudNotification\BackgroundJob;
+namespace OCA\TwoFactorNextcloudNotification\Exception;
 
-use OC\BackgroundJob\TimedJob;
-use OCA\TwoFactorNextcloudNotification\Service\TokenManager;
-
-class CleanupTokens extends TimedJob {
-
-	/** @var TokenManager */
-	private $tokenManager;
-
-	public function __construct(TokenManager $tokenManager) {
-		// Run once a day
-		$this->setInterval(3600);
-
-		$this->tokenManager = $tokenManager;
-	}
-
-	protected function run($argument) {
-		$this->tokenManager->cleanupTokens();
-	}
+class TokenExpireException extends \Exception {
 
 }

--- a/lib/Service/TokenManager.php
+++ b/lib/Service/TokenManager.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorNextcloudNotification\Service;
+
+use OCA\TwoFactorNextcloudNotification\AppInfo\Application;
+use OCA\TwoFactorNextcloudNotification\Db\Token;
+use OCA\TwoFactorNextcloudNotification\Db\TokenMapper;
+use OCA\TwoFactorNextcloudNotification\Exception\TokenExpireException;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Notification\IManager as NotificationManager;
+
+class TokenManager {
+
+	/** @var TokenMapper */
+	private $mapper;
+
+	/** @var NotificationManager */
+	private $notificationManager;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	public function __construct(TokenMapper $mapper,
+								NotificationManager $notificationManager,
+								ITimeFactory $timeFactory) {
+		$this->mapper = $mapper;
+		$this->notificationManager = $notificationManager;
+		$this->timeFactory = $timeFactory;
+	}
+
+	/**
+	 * @param int $attemptId
+	 * @return Token
+	 * @throws DoesNotExistException
+	 * @throws TokenExpireException
+	 */
+	public function getById(int $attemptId): Token {
+		return $this->validateToken($this->mapper->getById($attemptId));
+	}
+
+	/**
+	 * @param string $token
+	 * @return Token
+	 * @throws DoesNotExistException
+	 * @throws TokenExpireException
+	 */
+	public function getByToken(string $token): Token {
+		return $this->validateToken($this->mapper->getByToken($token));
+	}
+
+	/**
+	 * @param Token $token
+	 */
+	public function delete(Token $token) {
+		$this->clearNotification($token);
+		$this->mapper->delete($token);
+	}
+
+	/**
+	 * @param Token $token
+	 * @return Token
+	 */
+	public function update(Token $token): Token {
+		$this->clearNotification($token);
+		return $this->mapper->update($token);
+	}
+
+	public function cleanupTokens() {
+		$tokens = $this->mapper->getTokensForCleanup();
+
+		foreach ($tokens as $token) {
+			$this->delete($token);
+		}
+	}
+
+	public function generate(string $userId): Token {
+		return $this->mapper->generate($userId);
+	}
+
+	/**
+	 * @param Token $token
+	 */
+	protected function clearNotification(Token $token) {
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp(Application::APP_ID)
+			->setSubject('login_attempt')
+			->setObject('2fa_id', $token->getId());
+		$this->notificationManager->markProcessed($notification);
+	}
+
+	/**
+	 * @param Token $token
+	 * @return Token
+	 * @throws TokenExpireException
+	 */
+	protected function validateToken(Token $token): Token {
+		if (($this->timeFactory->getTime() - $token->getTimestamp()) > 60*10) {
+			$this->delete($token);
+			throw new TokenExpireException('Token expired');
+		}
+
+		return $token;
+	}
+}


### PR DESCRIPTION
Fixes #8

Introduces a tokenmanager. This adds a little logic between the dump
TokenMapper and the caller. It will cleanup the notifications if needed
and check if a token is still valid (10 minutes).

It also handles the removing of all the old tokens by cleaning up their
notifications.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>