### PR TITLE
Add compare links in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.2
+## [3.1.2](https://github.com/nickv-nextcloud/twofactor_nextcloud_notification/compare/v3.1.1...v3.1.2) - 2021-03-04
 ### Fixed
 - Installing with NC21
 
-## [3.1.1] - 2021-03-01
+## [3.1.1](https://github.com/nickv-nextcloud/twofactor_nextcloud_notification/compare/v3.1.0...v3.1.1) - 2021-03-01
 ### Changes
 - Made Doctrine 3.0 compatible for PHP8 support in Nextcloud 21
 
-## [3.1.0] - 2020-12-21
+## [3.1.0](https://github.com/nickv-nextcloud/twofactor_nextcloud_notification/compare/v3.0.0...v3.1.0) - 2020-12-21
 ### Added
 - Made 21 Compatible
 
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependency updates
 - Translation updates
 
-## [3.0.0] - 2020-08-28
+## [3.0.0](https://github.com/nickv-nextcloud/twofactor_nextcloud_notification/compare/v2.3.0...v3.0.0) - 2020-08-28
 ### Added
 - Made 20 compatible
 


### PR DESCRIPTION
I've fixed a typo in CHANGELOG.md and add some links for better comarison with older versions.

I've also noticed that there is no git tag for v3.1.1. Is this on purpose?